### PR TITLE
debug is property for the Prisma constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,8 @@ const server = new GraphQLServer({
       typeDefs: 'src/generated/prisma.graphql',
       endpoint: '__PRISMA_ENDPOINT__',
       secret: 'mysecret123',
+      debug: true,
     }),
-    debug: true,
   }),
 })
 


### PR DESCRIPTION
posting this because this [prisma tutorial](https://www.prisma.io/docs/tutorials/build-graphql-servers/development/build-a-realtime-graphql-server-with-subscriptions-ien5es6ok3/#1.1.-download-and-explore-the-starter-project) references the starter branch.